### PR TITLE
fix: resolve issue with max limit not increasing after GitHub connection

### DIFF
--- a/components/AirdropForm.tsx
+++ b/components/AirdropForm.tsx
@@ -53,6 +53,10 @@ export const AirdropForm = ({ className, rateLimit }: AirdropFormProps) => {
   const [network, setSelectedNetwork] = useState("devnet");
   const [isFormValid, setIsFormValid] = useState(false);
 
+  if (rateLimit.maxAmountPerRequest > 5) {
+    amountOptions.push(rateLimit.maxAmountPerRequest);
+  }
+
   const validateWallet = (address: string): boolean => {
     try {
       new PublicKey(address);
@@ -176,7 +180,7 @@ export const AirdropForm = ({ className, rateLimit }: AirdropFormProps) => {
     setIsFormValid(
       walletAddress !== "" &&
         amount !== null &&
-        amount <= 5 &&
+        amount <= 10 &&
         errors.wallet === "" &&
         errors.amount === "",
     );


### PR DESCRIPTION
# Fix: Airdrop Limit Not Increasing After GitHub Connection  

## Description  
This PR addresses an issue where connecting a GitHub account did not increase the maximum airdrop limit as expected. The system initially sets the limit at 5 SOL, and although users are informed that connecting their GitHub account unlocks a higher limit, the actual limit remains unchanged.  

### Changes Implemented  
- Updated the front end to reflect the increased airdrop limit dynamically.  

## Before and After Screenshots  

### Before Fix  
- **Without GitHub Connection (Limit: 5 SOL):**  

  ![Without GitHub Connection](https://github.com/user-attachments/assets/3889056b-dfdc-443c-ba49-25c08e256e5a)  

- **With GitHub Connection (Limit Still: 5 SOL):**  

  ![With GitHub Connection](https://github.com/user-attachments/assets/1def354b-05bc-44fd-8db4-1a46d53fea78)  

### After Fix  
- **Without GitHub Connection (Limit: 5 SOL):**  

  ![Post-Fix Without GitHub Connection](https://github.com/user-attachments/assets/6fa1fb37-834a-4c97-a098-e1ce35f00e4c)  

- **With GitHub Connection (Limit: Increased to 10 SOL):**  

  ![Post-Fix With GitHub Connection](https://github.com/user-attachments/assets/f2a7c66c-1376-4d67-a027-e820dfb8059c)  

## Testing  
- Verified that the limit remains 5 SOL for users without a connected GitHub account.  
- Tested the flow of connecting a GitHub account and observed the limit increase to the expected value.  

## Issue Reference  
Resolves #27

## Checklist   
- [x] Updates frontend to reflect the correct limit.  
- [x] Includes testing and validation for the fix.  

## Additional Notes  
If there are further improvements or suggestions, I am open to making adjustments. Thank you for reviewing this PR!  
