### PR TITLE
Drop only on-curve addresses check

### DIFF
--- a/app/api/request/route.ts
+++ b/app/api/request/route.ts
@@ -98,11 +98,6 @@ export const POST = withOptionalUserSession(async ({ req, session }) => {
 
       userWallet = new PublicKey(walletAddress);
 
-      // verify the wallet is not a PDA
-      if (!PublicKey.isOnCurve(userWallet.toBuffer())) {
-        throw Error("Address cannot be a PDA");
-      }
-
       // when here, the user provided wallet is considered valid
     } catch (err) {
       throw Error("Invalid wallet address");


### PR DESCRIPTION
Solana smart wallets are not on curve, so this check made it unusable