### PR TITLE
Document required env vars and clean up unused declarations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,101 @@
+# =============================================================================
+# Solana Devnet Faucet — environment variables
+# Copy to `.env.local` and fill in the values. Never commit real secrets.
+#
+# Sensitivity tags (always shown FIRST on each variable):
+#   [SECRET]      Treat as a credential. Never log, never commit, rotate if leaked.
+#                 Store only in Vercel env / a secrets manager / .env.local.
+#   [SEMI-SECRET] Not a credential, but leaking it weakens an abuse control
+#                 (e.g. lets clients bypass rate limits). Keep private.
+#   [PUBLIC]      Safe to log and share. Non-sensitive config.
+#
+# Requirement tags:
+#   [required]    Must be set or the app/feature breaks.
+#   [optional]    Has a working default.
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Solana
+# -----------------------------------------------------------------------------
+
+# [SECRET] [required] Faucet wallet keypair as a JSON-stringified byte array,
+# e.g. "[12,34,...]". Controls the faucet's funds — anyone with this can drain it.
+# Parsed by @solana-developers/helpers `getKeypairFromEnvironment`.
+FAUCET_KEYPAIR=
+
+# [SECRET] [optional] Solana RPC endpoint. Defaults to the public
+# https://api.devnet.solana.com when unset.
+# In practice, the only reason to set this is to point at a private provider
+# (Helius, QuickNode, Triton, Alchemy, etc.) — and those URLs typically embed
+# an API key directly in the path or query string, e.g.
+#   https://devnet.helius-rpc.com/?api-key=...
+#   https://solana-devnet.g.alchemy.com/v2/<key>
+# So treat the value as a credential: don't log, don't commit, rotate if leaked.
+RPC_URL=
+
+# -----------------------------------------------------------------------------
+# Cloudflare Turnstile (CAPTCHA)
+# -----------------------------------------------------------------------------
+
+# [SECRET] [required in production] Turnstile server-side secret key.
+# CAPTCHA check is skipped when NODE_ENV=development, so this is optional locally.
+# The matching sitekey is hardcoded in components/AirdropForm.tsx (public by design).
+CLOUDFLARE_SECRET=
+
+# -----------------------------------------------------------------------------
+# Auth (NextAuth v4 + GitHub OAuth)
+# -----------------------------------------------------------------------------
+
+# [SECRET] [required in production] Used by NextAuth to sign JWTs and cookies.
+# Leaking it lets attackers forge sessions for any user.
+# Generate with: openssl rand -base64 32
+# Read directly from env by NextAuth — not referenced in our code.
+NEXTAUTH_SECRET=
+
+# [PUBLIC] [optional on Vercel] Canonical site URL for NextAuth callbacks.
+# Auto-detected on Vercel via VERCEL_URL. Set this for non-Vercel deploys
+# or when running behind a reverse proxy locally. Defaults to http://localhost:3000 in dev.
+NEXTAUTH_URL=
+
+# [SEMI-SECRET] [required] GitHub OAuth client ID. Public-ish (it's sent to the
+# browser during OAuth flows), but treat as semi-private to limit scraping.
+# GitHub sign-in is mandatory (GITHUB_LOGIN_REQUIRED is hardcoded true in
+# app/api/request/route.ts).
+GITHUB_CLIENT_ID=
+
+# [SECRET] [required] GitHub OAuth client secret. Pairs with GITHUB_CLIENT_ID;
+# leaking it lets an attacker impersonate the OAuth app.
+GITHUB_CLIENT_SECRET=
+
+# -----------------------------------------------------------------------------
+# Backend API (analytics-324114 GCP project)
+# Provide ONE of these. If both are set, BE_TOKEN wins.
+# Without either, all backend calls (validation, transaction logging) fail.
+# -----------------------------------------------------------------------------
+
+# [SECRET] Pre-issued bearer token for the backend API. Easiest for local dev.
+BE_TOKEN=
+
+# [SECRET] Full GCP service account JSON, stringified onto a single line.
+# Highest-sensitivity item in this file: grants access to the GCP project.
+# Example: {"type":"service_account","project_id":"...", ...}
+BE_SERVICE_ACCOUNT_KEY=
+
+# -----------------------------------------------------------------------------
+# Allow lists (rate-limit bypass)
+# -----------------------------------------------------------------------------
+
+# [SEMI-SECRET] [optional] JSON array of IPs that bypass rate limits. Defaults to [].
+# Same abuse-control bypass as AUTH_TOKENS_ALLOW_LIST, but harder to exploit:
+# an attacker needs to either originate traffic from a listed IP or forge the
+# `cf-connecting-ip` header (possible if the origin is reachable without
+# Cloudflare in front — see app/api/request/route.ts:46-48).
+# Also reveals which parties have privileged access. Keep private.
+# Example: ["1.2.3.4","5.6.7.8"]
+IP_ALLOW_LIST=
+
+# [SECRET] [optional] JSON array of bypass tokens with optional active windows.
+# Defaults to []. Each token grants any holder the ability to bypass faucet
+# rate limits — treat exactly like an API key and rotate if leaked.
+# Example: [{"name":"hackathon","token":"abc123","startDate":"2026-04-01","endDate":"2026-04-30"}]
+AUTH_TOKENS_ALLOW_LIST=

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ yarn-error.log*
 yarn.lock
 
 # local env files
+.env
 .env*.local
 
 # vercel

--- a/lib/auth/options.ts
+++ b/lib/auth/options.ts
@@ -18,11 +18,6 @@ export const authOptions: NextAuthOptions = {
         };
       },
     }),
-    // Twitter({
-    //   clientId: process.env.TWITTER_CLIENT_ID,
-    //   clientSecret: process.env.TWITTER_CLIENT_SECRET,
-    //   version: "2.0",
-    // }),
   ],
   pages: {
     signIn: "/?signin",

--- a/types.d.ts
+++ b/types.d.ts
@@ -24,22 +24,22 @@ declare namespace NodeJS {
      */
     RPC_URL: string;
     FAUCET_KEYPAIR: string;
-    // NEXT_PUBLIC_RPC_URL: string;
 
-    POSTGRES_STRING: string;
     CLOUDFLARE_SECRET: string;
     IP_ALLOW_LIST: string;
+    AUTH_TOKENS_ALLOW_LIST: string;
+
+    /**
+     * Backend API authentication
+     */
+    BE_TOKEN: string;
+    BE_SERVICE_ACCOUNT_KEY: string;
 
     /**
      * Auth related variables
      */
-
-    // GITHUB_ID: string;
+    NEXTAUTH_SECRET: string;
     GITHUB_CLIENT_ID: string;
     GITHUB_CLIENT_SECRET: string;
-    // GITHUB_ACCESS_TOKEN: string;
-
-    // TWITTER_CLIENT_ID: string;
-    // TWITTER_CLIENT_SECRET: string;
   }
 }


### PR DESCRIPTION
## Summary

- Adds `.env.example` covering all 11 environment variables the app actually reads, with explicit sensitivity tags (`[SECRET]` / `[SEMI-SECRET]` / `[PUBLIC]`) and requirement tags (`[required]` / `[optional]`) on every variable. There's currently no documentation of which env vars the project needs to run, beyond `types.d.ts`.
- Adds `NEXTAUTH_SECRET` and `NEXTAUTH_URL` — read implicitly by NextAuth v4 with no `process.env` reference in code, so they were previously undocumented and easy to miss when setting up the project.
- Adds `BE_TOKEN`, `BE_SERVICE_ACCOUNT_KEY`, and `AUTH_TOKENS_ALLOW_LIST` to `types.d.ts` — used in code but previously untyped.
- Removes `POSTGRES_STRING` from `types.d.ts` and the commented-out Twitter provider from `lib/auth/options.ts` — neither is referenced anywhere.
- Adds `.env` to `.gitignore` (previously only `.env*.local` was ignored), so a plain `.env` at the repo root won't be committed by accident. Verified across full git history that no `.env` file has ever been committed.

## Sensitivity classification

| Tier | Variables |
|---|---|
| `[SECRET]` | `FAUCET_KEYPAIR`, `RPC_URL`, `CLOUDFLARE_SECRET`, `NEXTAUTH_SECRET`, `GITHUB_CLIENT_SECRET`, `BE_TOKEN`, `BE_SERVICE_ACCOUNT_KEY`, `AUTH_TOKENS_ALLOW_LIST` |
| `[SEMI-SECRET]` | `GITHUB_CLIENT_ID`, `IP_ALLOW_LIST` |
| `[PUBLIC]` | `NEXTAUTH_URL` |

`RPC_URL` is tagged `[SECRET]` because the only practical reason to set it is to point at a private provider (Helius, QuickNode, etc.) whose URL embeds an API key. `IP_ALLOW_LIST` is `[SEMI-SECRET]` because the code at `app/api/request/route.ts:46-48` trusts `cf-connecting-ip` unconditionally — leaked IPs become a direct rate-limit bypass via header forgery if the origin is ever reachable without Cloudflare in front.

## Out of scope (worth following up separately)

- The unconditional trust of `cf-connecting-ip` mentioned above is a real abuse-control gap — worth either validating against Cloudflare's published IP ranges or requiring a shared-secret header set at the edge.
- `@vercel/edge-config` and `pg` are declared in `package.json` but never imported anywhere; safe to drop.

## Test plan

- [ ] Confirm CI / `next build` still passes (only doc/type/gitignore changes; no runtime code touched).
- [ ] Confirm `git log --all -- '.env*'` returns nothing (already verified locally).
- [ ] Spot-check the sensitivity tags against your deployment's actual env values to make sure the wording matches your team's threat model.