### PR TITLE
fix(analytics): wrap GA4 fetch in waitUntil to prevent dropped events

### DIFF
--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -10,6 +10,8 @@
  *   GA4_API_SECRET      – created in GA4 Admin › Data Streams › Measurement Protocol API secrets
  */
 
+import { waitUntil } from "@vercel/functions";
+
 const GA4_ENDPOINT = "https://www.google-analytics.com/mp/collect";
 
 type EventParams = Record<string, string | number | boolean | undefined>;
@@ -41,14 +43,16 @@ export function trackEvent(
     if (v !== undefined) cleanParams[k] = v;
   }
 
-  fetch(url, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      client_id: clientId,
-      events: [{ name, params: cleanParams }],
+  waitUntil(
+    fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        client_id: clientId,
+        events: [{ name, params: cleanParams }],
+      }),
+    }).catch((err) => {
+      console.error(`[ANALYTICS] Failed to send event "${name}":`, err);
     }),
-  }).catch((err) => {
-    console.error(`[ANALYTICS] Failed to send event "${name}":`, err);
-  });
+  );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@types/react": "18.2.14",
         "@types/react-dom": "18.2.6",
         "@vercel/edge-config": "^0.2.1",
+        "@vercel/functions": "^3.6.0",
         "autoprefixer": "10.4.14",
         "class-variance-authority": "^0.7.0",
         "eslint": "8.44.0",
@@ -434,9 +435,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -452,9 +450,6 @@
       "integrity": "sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -472,9 +467,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -490,9 +482,6 @@
       "integrity": "sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2287,6 +2276,35 @@
       "resolved": "https://registry.npmjs.org/@vercel/edge-config-fs/-/edge-config-fs-0.1.0.tgz",
       "integrity": "sha512-NRIBwfcS0bUoUbRWlNGetqjvLSwgYH/BqKqDN7vK1g32p7dN96k0712COgaz6VFizAm9b0g6IG6hR6+hc0KCPg==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@vercel/functions": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@vercel/functions/-/functions-3.6.0.tgz",
+      "integrity": "sha512-Xj68JYqqJwtqFWJN7EWmFN7MOiUjv5whjw48UEKqQbg8r7hRkhuJhncTU0ba3jJCh/wxEuLWckrtsKcrHQraxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/oidc": "3.4.1"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-web-identity": "*"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-web-identity": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.4.1.tgz",
+      "integrity": "sha512-H6B+/ig/GoahccL3WZjiHayHw1H5KhvTJNceqYulwfK9kkz5iul2hTmYzcJ7tTCQzyd0dutuL9xYFZCyLUqsog==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.5",
@@ -9833,6 +9851,19 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@vercel/edge-config-fs/-/edge-config-fs-0.1.0.tgz",
       "integrity": "sha512-NRIBwfcS0bUoUbRWlNGetqjvLSwgYH/BqKqDN7vK1g32p7dN96k0712COgaz6VFizAm9b0g6IG6hR6+hc0KCPg=="
+    },
+    "@vercel/functions": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@vercel/functions/-/functions-3.6.0.tgz",
+      "integrity": "sha512-Xj68JYqqJwtqFWJN7EWmFN7MOiUjv5whjw48UEKqQbg8r7hRkhuJhncTU0ba3jJCh/wxEuLWckrtsKcrHQraxw==",
+      "requires": {
+        "@vercel/oidc": "3.4.1"
+      }
+    },
+    "@vercel/oidc": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.4.1.tgz",
+      "integrity": "sha512-H6B+/ig/GoahccL3WZjiHayHw1H5KhvTJNceqYulwfK9kkz5iul2hTmYzcJ7tTCQzyd0dutuL9xYFZCyLUqsog=="
     },
     "@vitest/expect": {
       "version": "4.1.5",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@types/react": "18.2.14",
     "@types/react-dom": "18.2.6",
     "@vercel/edge-config": "^0.2.1",
+    "@vercel/functions": "^3.6.0",
     "autoprefixer": "10.4.14",
     "class-variance-authority": "^0.7.0",
     "eslint": "8.44.0",


### PR DESCRIPTION
## Summary

The fire-and-forget `fetch()` in `trackEvent()` (`lib/analytics.ts`) returns a dangling Promise that the Vercel serverless runtime cancels the moment the response is returned. With `GA4_MEASUREMENT_ID` / `GA4_API_SECRET` correctly set in production, events were still never reaching `google-analytics.com` because the POST was cut off mid-flight — silently, since GA4's `/mp/collect` returns 204 regardless of whether anything was actually sent.

This was introduced together with the analytics module in #57.

## Fix

Wrap the fetch in `waitUntil()` from `@vercel/functions` so the runtime keeps the function instance alive until the GA4 request settles — without blocking the airdrop response.

```ts
import { waitUntil } from "@vercel/functions";

waitUntil(
  fetch(url, { method: "POST", ... }).catch((err) => {
    console.error(`[ANALYTICS] Failed to send event "${name}":`, err);
  }),
);
```

## Why `waitUntil` and not `await`?

`await` is also a valid fix — the cost is ~50–100 ms added to a request that's already 1–3 seconds (Turnstile + Solana RPC + backend logging). The choice for `waitUntil` here is to preserve the doc-stated contract that `trackEvent` "never blocks the airdrop response," and to isolate the airdrop path from any GA4 outage / TLS hang.

`waitUntil` is runtime-agnostic and reads a context object Vercel injects on `globalThis`. It does **not** change the deploy type, the runtime (Node.js Fluid Compute), regions, or pricing. Outside Vercel (self-hosted) it silently no-ops, matching the prior fire-and-forget semantics.

## Test plan

- [x] `npx vitest run` — all 111 tests pass locally (no test changes required; existing tracking tests mock `@/lib/analytics`)
- [ ] Deploy to a preview / staging environment with `GA4_MEASUREMENT_ID` + `GA4_API_SECRET` set
- [ ] Trigger an airdrop and confirm `airdrop_success` appears in GA4 Realtime within ~30 sec
- [ ] Trigger a failure path (invalid wallet) and confirm `airdrop_failed` with `reason` param appears
- [ ] Optional: temporarily swap the endpoint to `/debug/mp/collect` once to validate payload shape (GA4 silently drops invalid events on the prod endpoint)