### PR TITLE
feat(analytics): add client-side gtag.js to root layout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -116,3 +116,11 @@ GA4_MEASUREMENT_ID=
 # Protocol API secrets. Leaking it lets anyone forge events into your GA4
 # property. Required only if GA4_MEASUREMENT_ID is set.
 GA4_API_SECRET=
+
+# [PUBLIC] [optional] GA4 Measurement ID for client-side gtag.js page-view
+# tracking. Format: "G-XXXXXXXXXX". Inlined into the bundle at build time
+# via the NEXT_PUBLIC_ prefix — served to every visitor in the gtag.js
+# script src, so not sensitive. When unset, app/layout.tsx skips rendering
+# the GA4 <Script> tags entirely. Typically the same value as
+# GA4_MEASUREMENT_ID (same GA4 property) — keep them in sync.
+NEXT_PUBLIC_GA4_MEASUREMENT_ID=

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
+import Script from "next/script";
 import { Header } from "@/components/header";
 import { Footer } from "@/components/ui/footer";
 import "./globals.css";
@@ -26,6 +27,8 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
+  const gaId = process.env.NEXT_PUBLIC_GA4_MEASUREMENT_ID;
+
   return (
     <html lang="en">
       <body className={`${inter.className}`}>
@@ -36,6 +39,23 @@ export default function RootLayout({
         </section>
 
         <Footer />
+
+        {gaId && (
+          <>
+            <Script
+              src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`}
+              strategy="afterInteractive"
+            />
+            <Script id="ga4-init" strategy="afterInteractive">
+              {`
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+                gtag('config', '${gaId}');
+              `}
+            </Script>
+          </>
+        )}
       </body>
     </html>
   );

--- a/types.d.ts
+++ b/types.d.ts
@@ -44,6 +44,14 @@ declare namespace NodeJS {
     GA4_API_SECRET: string;
 
     /**
+     * Client-side analytics (gtag.js). Optional — the GA4 <Script>
+     * tags in app/layout.tsx render only when this is set. Public by
+     * design (served to every visitor in the script src), so safe to
+     * expose with the NEXT_PUBLIC_ prefix.
+     */
+    NEXT_PUBLIC_GA4_MEASUREMENT_ID: string;
+
+    /**
      * Auth related variables
      */
     NEXTAUTH_SECRET: string;


### PR DESCRIPTION
## Summary

- Render the GA4 `gtag.js` snippet from `app/layout.tsx` via `next/script`, so page views and client interactions land in the GA4 property the server-side Measurement Protocol code (#57) already writes to.
- Driven by `NEXT_PUBLIC_GA4_MEASUREMENT_ID` — when unset, the `<Script>` tags don't render at all, so the bundle stays clean in environments without analytics.
- Document the new var in `.env.example` (with a note to keep it in sync with the server-side `GA4_MEASUREMENT_ID` — same GA4 property), and add it to `ProcessEnv` in `types.d.ts`.

## Why `next/script` and not raw `<script>` tags

`next/script` manages load timing (`strategy="afterInteractive"`) and dedupes across client-side navigations. Drop-in raw `<script>` tags inside JSX work but bypass Next's optimizations and can fire multiple times when re-rendering.

## Why a separate env var from `GA4_MEASUREMENT_ID`

The server-side var is referenced in API routes (Node.js runtime) and stays private to the server bundle. The client needs the `NEXT_PUBLIC_` prefix to be inlined at build time. They're conventionally the same value (same GA4 property), but kept as two vars so the team can:
- Disable client tracking without disabling server tracking, or vice versa
- Point preview deployments at a separate GA4 property without affecting the server-side Measurement Protocol writes

Documented in `.env.example` so the sync expectation is explicit.

## What's NOT changed

Server-side analytics in `lib/analytics.ts` is untouched. The related `waitUntil` fix lives in #59 — independent concern, independent PR.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — all 111 tests pass
- [ ] Set `NEXT_PUBLIC_GA4_MEASUREMENT_ID=G-XXXX` in a preview deployment; verify the two `<script>` tags appear in the page source and that page views show up in GA4 Realtime within ~30 sec
- [ ] Confirm with the var unset, no GA4 script tags appear in the rendered HTML